### PR TITLE
Allows configurable OCS app name

### DIFF
--- a/rules/ocs/README.md
+++ b/rules/ocs/README.md
@@ -58,6 +58,7 @@ In a `BUILD.bazel` file refer to the rules as follows:
         ],
         dpa_file = "path/to/myproject.dpa", # The dpa file if a project is modified and not created
         ocs_app = "path/to/myocs-app.jar", # The .jar file of the ocs app
+        ocs_app_name = "OcsCustomApp:OCS", # Optional name of ocs app to be executed
         ocs_config_files = glob([ # The ocs plugin json files from ocs home directory
             "path/to/myconfig.json",
         ]),

--- a/rules/ocs/rules.bzl
+++ b/rules/ocs/rules.bzl
@@ -224,7 +224,7 @@ def _ocs_impl(ctx):
         cfg5cli_path = cf5gcli,
         output_folder = output_folder,
         script_location = ctx.file.ocs_app.dirname,
-        script_task = "OCS",
+        script_task = ctx.attr.ocs_app_name or "OCS",
         task_args = ocs_args,
         cfg5_args = cfg5_args.replace("$(OUTS)", output_folder),
     )
@@ -263,6 +263,7 @@ def _ocs_impl(ctx):
 ocs_attrs = {
     "cfg5_args": attr.string(doc = "Additional arguments for the cfg5 run"),
     "ocs_app": attr.label(allow_single_file = True, doc = "The .jar file of the ocs app"),
+    "ocs_app_name" : attr.string(mandatory = False, doc = "The name of the ocs app, used to execute the proper script in .jar file"),
     "dpa_file": attr.label(mandatory = False, allow_single_file = True, doc = "The .dpa file if a project is modified and not created"),
     "input_files": attr.label_list(allow_empty = True, allow_files = [".arxml", ".cdd", ".dbc"], doc = "Inputfiles if inputfile update is executed"),
     "davinci_project_files": attr.label_list(allow_empty = True, allow_files = True, doc = "Project files if a project is modified"),


### PR DESCRIPTION
Allows users to specify the OCS application name.

- Enables execution of specific scripts within the OCS application's .jar file
- Provides flexibility for customized OCS application setups